### PR TITLE
opt_score update in tune_threshold method

### DIFF
--- a/baselines/models.py
+++ b/baselines/models.py
@@ -276,4 +276,5 @@ class RNNSL:
                          tokens, scores in list(zip(validation_data[0], predictions))]
             score = np.mean([evaluator(p, g) for p, g in list(zip(decisions, validation_data[1]))])
             if score > opt_score:
+                opt_score = score
                 self.threshold = thr/100.


### PR DESCRIPTION
I think that the variable opt_score in the tune_threshold method does not get updated throughout the for loop. As a result, each score is compared only with the initial score and consequently the threshold gets updated. This leads to extracting a threshold that is not optimal but rather better than the score of the initial threshold of the model (0.2 defined in the constructor). 

A test of the new code was implemented [here](https://colab.research.google.com/drive/1k30kyUHHWYJCGiXAl2UzSV9U8m-81yOH?usp=sharing)

Please let me know if I have understood wrongly the use of this method or if you need extra support from my side on this PR.